### PR TITLE
Feature/css bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "deploy": "gulp deploy"
   },
   "devDependencies": {
+    "@bva/gulp-shopify-upload": "^2.5.0",
     "autoprefixer": "^9.5.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
@@ -28,7 +29,8 @@
     "dotenv": "^7.0.0",
     "glob": "^7.1.4",
     "gulp": "^4.0.0",
-    "gulp-changed": "^3.2.0",
+    "gulp-cached": "^1.1.1",
+    "gulp-changed": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-flatten": "^0.4.0",
     "gulp-if": "^2.0.2",
@@ -36,7 +38,6 @@
     "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.4.0",
     "gulp-sass": "^4.0.2",
-    "@bva/gulp-shopify-upload": "^2.5.0",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-svgstore": "^7.0.1",
     "gulp-uglify": "^3.0.2",

--- a/src/scripts/components/dynamic/SampleSection.vue
+++ b/src/scripts/components/dynamic/SampleSection.vue
@@ -1,6 +1,6 @@
 // Template
 <template>
-  <section :class="settings.title_position">
+  <section :class="sectionClass">
     <picture>
       <img :src="settings.image" />
     </picture>
@@ -18,6 +18,11 @@ export default {
     },
   },
   methods: {},
+  computed: {
+    sectionClass() {
+      return `sample-section ${this.settings.title_position}`;
+    },
+  },
   created() {},
 };
 </script>

--- a/src/styles/components/sample-section.scss
+++ b/src/styles/components/sample-section.scss
@@ -1,0 +1,3 @@
+.sample-section {
+  border: 4px solid $color-black;
+}

--- a/src/styles/templates/index/index.scss
+++ b/src/styles/templates/index/index.scss
@@ -1,0 +1,4 @@
+// Settings
+@import '../../boilerplate';
+
+@import '../../components/sample-section';

--- a/src/styles/templates/index/old-index.scss
+++ b/src/styles/templates/index/old-index.scss
@@ -1,0 +1,6 @@
+// Settings
+@import '../../boilerplate';
+
+body {
+  background-color: black !important;
+}

--- a/src/styles/templates/product/index.scss
+++ b/src/styles/templates/product/index.scss
@@ -1,0 +1,5 @@
+// Settings
+@import '../../boilerplate';
+.hello {
+  color: #fff;
+}

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -1,39 +1,65 @@
-
-var gulp         = require('gulp');
-var rename       = require('gulp-rename');
-var uglifyCSS    = require('gulp-uglifycss');
-var sourcemaps   = require('gulp-sourcemaps');
-var sass         = require('gulp-sass');
-var postcss      = require('gulp-postcss');
+var path = require('path');
+var gulp = require('gulp');
+var rename = require('gulp-rename');
+var cache = require('gulp-cached');
+var uglifyCSS = require('gulp-uglifycss');
+var sourcemaps = require('gulp-sourcemaps');
+var sass = require('gulp-sass');
+var postcss = require('gulp-postcss');
 var autoprefixer = require('autoprefixer');
 
-var stylesPath = 'src/styles/theme.scss';
+var globalStylesPath = 'src/styles/theme.scss';
+var templateStylesPath = 'src/styles/templates/**/index.scss';
 var stylesDest = 'dist/assets';
 
-var sassSettings = { 
-  includePaths: ['node_modules'] 
+var sassSettings = {
+  includePaths: ['node_modules'],
 };
 
-gulp.task('styles:dev', function () {
-  return gulp.src(stylesPath)
+gulp.task('styles:dev', function() {
+  return gulp
+    .src([templateStylesPath, globalStylesPath])
     .pipe(sourcemaps.init())
     .pipe(sass(sassSettings).on('error', sass.logError))
-    .pipe(postcss([ autoprefixer() ]))
+    .pipe(postcss([autoprefixer()]))
+    .pipe(cache('styles'))
     .pipe(sourcemaps.write())
-    .pipe(rename('bvaccel.css.liquid'))
+    .pipe(
+      rename(function(file) {
+        file.extname = '.scss.liquid';
+        if (file.dirname !== '.') {
+          file.basename = `template.${file.dirname}`;
+          file.dirname = '';
+        }
+        return file;
+      }),
+    )
     .pipe(gulp.dest(stylesDest));
 });
 
-gulp.task('styles:prod', function () {
-  return gulp.src(stylesPath)
+gulp.task('styles:prod', function() {
+  return gulp
+    .src([templateStylesPath, globalStylesPath])
+    .pipe(sourcemaps.init())
     .pipe(sass(sassSettings).on('error', sass.logError))
-    .pipe(postcss([ autoprefixer() ]))
+    .pipe(postcss([autoprefixer()]))
     .pipe(uglifyCSS())
-    .pipe(rename('bvaccel.css.liquid'))
+    .pipe(cache('styles'))
+    .pipe(sourcemaps.write())
+    .pipe(
+      rename(function(file) {
+        file.extname = '.scss.liquid';
+        if (file.dirname !== '.') {
+          file.basename = `template.${file.dirname}`;
+          file.dirname = '';
+        }
+        return file;
+      }),
+    )
     .pipe(gulp.dest(stylesDest));
 });
 
-gulp.task('styles:watch', function (done) {
+gulp.task('styles:watch', function(done) {
   gulp.watch('src/styles/**/*', gulp.series('styles:dev'));
   done();
 });

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+// const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const glob = require('glob');
 const jsBundleTypes = ['layout', 'templates'];
@@ -40,7 +40,8 @@ module.exports = (env) => ({
       {
         test: /\.scss$/,
         use: [
-          env.mode === 'production' ? MiniCssExtractPlugin.loader : 'vue-style-loader',
+          // env.mode === 'production' ? MiniCssExtractPlugin.loader : 'vue-style-loader',
+          'vue-style-loader',
           'css-loader',
           {
             loader: 'sass-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2648,15 +2648,21 @@ group-array@^1.0.0:
     split-string "^6.1.0"
     union-value "^2.0.1"
 
-gulp-changed@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/gulp-changed/-/gulp-changed-3.2.0.tgz#cee9866d949e09187522523d6c65565f6e32bd7c"
+gulp-cached@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/gulp-cached/-/gulp-cached-1.1.1.tgz#fe7cd4f87f37601e6073cfedee5c2bdaf8b6acce"
   dependencies:
-    make-dir "^1.1.0"
-    pify "^3.0.0"
-    plugin-error "^0.1.2"
+    lodash.defaults "^4.2.0"
+    through2 "^2.0.1"
+
+gulp-changed@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/gulp-changed/-/gulp-changed-4.0.2.tgz#387c6b05a3d18519281516ebf8f49f2d5d56efd3"
+  dependencies:
+    make-dir "^3.0.0"
+    plugin-error "^1.0.1"
     replace-ext "^1.0.0"
-    through2 "^2.0.0"
+    through2 "^3.0.1"
     touch "^3.1.0"
 
 gulp-clean@^0.4.0:
@@ -3601,7 +3607,7 @@ lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
-lodash.defaults@^4.0.1:
+lodash.defaults@^4.0.1, lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
@@ -3706,7 +3712,7 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
-make-dir@^1.0.0, make-dir@^1.1.0:
+make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   dependencies:
@@ -3718,6 +3724,12 @@ make-dir@^2.0.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  dependencies:
+    semver "^6.0.0"
 
 make-error-cause@^1.1.1:
   version "1.2.2"
@@ -5220,7 +5232,7 @@ semver-greatest-satisfied-range@^1.1.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
 
-semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
 


### PR DESCRIPTION
- Updated gulp `styles` task to build separate stylesheet bundles for each template as well as a global theme stylesheet.
- Removed use of mini-css-extract plugin in webpack (uses gulp instead)